### PR TITLE
Creating example-config.json file with reference to config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-cypress/fixtures/example.json
+cypress/fixtures/config.json

--- a/cypress/e2e/typeformAPI.cy.js
+++ b/cypress/e2e/typeformAPI.cy.js
@@ -1,7 +1,7 @@
 describe("API Tests", () => {
-  const exampleData = require("../fixtures/example.json");
+  const configData = require("../fixtures/config.json");
   const sampleForm = require("../fixtures/sampleForm.json");
-  const authorization = `Bearer ${exampleData.ACCESS_TOKEN}`;
+  const authorization = `Bearer ${configData.ACCESS_TOKEN}`;
   const API_URL = Cypress.env("API_BASE_URL");
 
 
@@ -13,8 +13,8 @@ describe("API Tests", () => {
     }).should(({ status, body }) => {
       const { alias, email, language } = body;        //diariamente a API typeForm muda o nome de {alias > name} e vice e versa
       expect(status).to.eq(200);
-      expect(alias).to.eq(exampleData.userAlias);     //verifique o yielded.body do console para validar em caso de erro
-      expect(email).to.eq(exampleData.username);
+      expect(alias).to.eq(configData.userAlias);     //verifique o yielded.body do console para validar em caso de erro
+      expect(email).to.eq(configData.username);
       expect(language).to.eq("en");
     });
   });
@@ -22,7 +22,7 @@ describe("API Tests", () => {
   it("retrieves form responses", () => {
     cy.request({
       method: "GET",
-      url: `${API_URL}forms/${exampleData.formId}/responses`,
+      url: `${API_URL}forms/${configData.formId}/responses`,
       headers: { authorization },
     }).should(({ status, body }) => {
       expect(status).to.eq(200);

--- a/cypress/fixtures/example-config.json
+++ b/cypress/fixtures/example-config.json
@@ -1,0 +1,7 @@
+{
+    "ACCESS_TOKEN": "you-acess-token-here",
+    "username": "user@example.com",
+    "password": "40cjG9-#jk2Id9",
+    "userAlias": "Sample User",
+    "formId": "form-id-here"
+  }


### PR DESCRIPTION
**Adição de `example-config.json`:**  
Foi adicionado um novo arquivo `example-config.json` ao repositório. Este arquivo serve como referência para a configuração e fornece exemplos das informações que estão presentes no `config.json`, que contém dados sensíveis e está listado no `.gitignore`. O `example-config.json` permite que os desenvolvedores vejam quais são as configurações esperadas sem expor dados sensíveis.

**Correções no Código:**  
Devido à mudança, foi necessário atualizar o código para refletir a nova referência para o `example-config.json`, ao invés do antigo `example.json`. Essas atualizações garantem que o código esteja alinhado com a nova estrutura de configuração e que a segurança dos dados sensíveis seja mantida.

**Motivo da Mudança:**

- Melhorar a segurança dos dados sensíveis no repositório.
- Fornecer uma documentação clara das configurações necessárias para novos desenvolvedores ou colaboradores.